### PR TITLE
feat: Add file timestamps and sort by date functionality

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -27,18 +27,60 @@ jobs:
           python -c "
           import os
           import json
+          import subprocess
+          import datetime
 
           report_dir = 'report'
+          reports_with_timestamps = []
+          default_timestamp = '2025/06/06 00:00:00'
+
           if not os.path.exists(report_dir):
               print(f\"Directory '{report_dir}' not found. Creating an empty report_list.json.\")
-              report_files = []
           else:
-              report_files = [f for f in os.listdir(report_dir) if f.endswith('.html')]
-          
-          report_files.sort()
+              report_files_names = [f for f in os.listdir(report_dir) if f.endswith('.html')]
+
+              for file_name in report_files_names:
+                  file_path = os.path.join(report_dir, file_name)
+                  formatted_timestamp = default_timestamp
+                  try:
+                      # Get the last commit date for the file
+                      result = subprocess.run(
+                          ['git', 'log', '-1', '--pretty=format:%cI', '--', file_path],
+                          capture_output=True, text=True, check=False, encoding='utf-8'
+                      )
+
+                      git_timestamp_str = result.stdout.strip()
+
+                      if result.returncode == 0 and git_timestamp_str:
+                          # Handle 'Z' for UTC if present, replace with +00:00 for fromisoformat
+                          if git_timestamp_str.endswith('Z'):
+                              git_timestamp_str = git_timestamp_str[:-1] + '+00:00'
+
+                          # Handle timezone offsets that might not have a colon in older git versions (e.g. +0200)
+                          # Python's fromisoformat expects a colon (e.g. +02:00)
+                          if len(git_timestamp_str) > 6 and git_timestamp_str[-5] in ['+', '-'] and git_timestamp_str[-3] != ':':
+                             git_timestamp_str = git_timestamp_str[:-2] + ":" + git_timestamp_str[-2:]
+
+                          parsed_date = datetime.datetime.fromisoformat(git_timestamp_str)
+                          formatted_timestamp = parsed_date.strftime('%Y/%m/%d %H:%M:%S')
+                      elif result.returncode != 0:
+                          print(f\"Git log command failed for {file_path} (exit code {result.returncode}): {result.stderr.strip()}\")
+                          print(f\"Using default timestamp for {file_name}\")
+                      else: # Empty timestamp
+                          print(f\"No git timestamp found for {file_path}. It might be a new, uncommitted file. Using default timestamp.\")
+
+                  except ValueError as ve:
+                      print(f\"ValueError parsing date '{git_timestamp_str}' for file {file_name}: {ve}. Using default timestamp.\")
+                  except Exception as e:
+                      print(f\"An unexpected error occurred while processing {file_name}: {e}. Using default timestamp.\")
+
+                  reports_with_timestamps.append({'name': file_name, 'timestamp': formatted_timestamp})
+
+              # Sort by filename
+              reports_with_timestamps.sort(key=lambda x: x['name'])
 
           with open('report_list.json', 'w') as f:
-            json.dump(report_files, f, indent=2)
+            json.dump(reports_with_timestamps, f, indent=2)
           
           print(\"Generated report_list.json:\")
           with open('report_list.json', 'r') as f:

--- a/index.html
+++ b/index.html
@@ -27,14 +27,19 @@
       <div class="col s12">
         <h4 class="header_text center-align" style="font-family: 'Roboto', sans-serif; color: #263238;">Available Reports</h4>
         <div class="row" style="margin-bottom: 20px;">
-          <div class="col s12 m6 l4 push-l2">
+          <div class="col s12 m4 l4">
             <button id="sort-by-title-btn" class="btn waves-effect waves-light blue darken-1" style="width:100%;">Sort by Title
               <i class="material-icons left">sort_by_alpha</i>
             </button>
           </div>
-          <div class="col s12 m6 l4 push-l2">
+          <div class="col s12 m4 l4">
             <button id="sort-by-filename-btn" class="btn waves-effect waves-light green darken-1" style="width:100%;">Sort by Filename
               <i class="material-icons left">sort</i>
+            </button>
+          </div>
+          <div class="col s12 m4 l4">
+            <button id="sort-by-date-btn" class="btn waves-effect waves-light orange darken-1" style="width:100%;">Sort by Date
+              <i class="material-icons left">date_range</i>
             </button>
           </div>
         </div>
@@ -90,6 +95,7 @@
                         <div class="card-content">
                           <span class="card-title truncate">${report.title}</span>
                           <p class="grey-text text-darken-1" style="font-size: 0.9rem;">${report.fileName}</p>
+                          <p class="grey-text text-lighten-1" style="font-size: 0.8rem; margin-top: 4px;">${report.timestamp}</p>
                         </div>
                         <div class="card-action">
                           <a href="${report.reportFilePath}" class="blue-text text-accent-4">View Report</a>
@@ -108,21 +114,25 @@
                 }
                 return response.json();
             })
-            .then(reportFiles => {
+            .then(reportFileObjects => { // Renamed for clarity, this is now an array of objects
                 if (!reportCardsContainer) {
                     console.error('Error: report-cards-container div not found initially.');
                     document.body.insertAdjacentHTML('beforeend', '<p class="red-text container center-align">Error: Report container div not found in HTML.</p>');
                     return;
                 }
 
-                if (!Array.isArray(reportFiles) || reportFiles.length === 0) {
+                if (!Array.isArray(reportFileObjects) || reportFileObjects.length === 0) {
                     reportCardsContainer.innerHTML = '<p class="flow-text center-align">No reports listed in report_list.json. Add HTML files to the "report" directory and ensure the GitHub Action has run.</p>';
                     return []; // Return empty array to Promise.all
                 }
 
-                const fetchPromises = reportFiles.map(fileName => {
-                    if (typeof fileName === 'string' && fileName.endsWith('.html')) {
+                const fetchPromises = reportFileObjects.map(item => {
+                    // Ensure item is an object and has name & timestamp properties
+                    if (typeof item === 'object' && item && typeof item.name === 'string' && item.name.endsWith('.html') && typeof item.timestamp === 'string') {
+                        const fileName = item.name;
+                        const fileTimestamp = item.timestamp;
                         const reportFilePath = `report/${fileName}`;
+
                         return fetch(reportFilePath)
                             .then(response => {
                                 if (!response.ok) {
@@ -135,14 +145,16 @@
                                 if (!htmlContent) return null;
                                 const titleMatch = /<title>(.*?)<\/title>/i.exec(htmlContent);
                                 const title = titleMatch && titleMatch[1] ? titleMatch[1] : fileName;
-                                return { title, fileName, reportFilePath };
+                                // Include timestamp in the resolved object
+                                return { title, fileName, reportFilePath, timestamp: fileTimestamp };
                             })
                             .catch(error => {
                                 console.error(`Error processing report ${fileName}:`, error);
                                 return null; // Skip this report on error
                             });
                     }
-                    return Promise.resolve(null); // Skip non-string or non-html files
+                    console.warn('Skipping invalid item in report_list.json:', item);
+                    return Promise.resolve(null); // Skip malformed items
                 });
 
                 return Promise.all(fetchPromises);
@@ -172,6 +184,15 @@
         function setupSortingEventListeners() {
             const sortByTitleBtn = document.getElementById('sort-by-title-btn');
             const sortByFilenameBtn = document.getElementById('sort-by-filename-btn');
+            const sortByDateBtn = document.getElementById('sort-by-date-btn');
+
+            // Helper function to parse "YYYY/MM/DD HH:MM:SS" into a Date object
+            function parseTimestamp(tsString) {
+                if (!tsString) return new Date(0); // Return epoch if timestamp is missing, for safety
+                const parts = tsString.split(/[/ :]/);
+                // new Date(year, monthIndex (0-11), day, hours, minutes, seconds)
+                return new Date(parts[0], parts[1] - 1, parts[2], parts[3], parts[4], parts[5]);
+            }
 
             if (sortByTitleBtn) {
                 sortByTitleBtn.addEventListener('click', () => {
@@ -189,6 +210,19 @@
                 });
             } else {
                 console.error("Sort by Filename button not found.");
+            }
+
+            if (sortByDateBtn) {
+                sortByDateBtn.addEventListener('click', () => {
+                    reportsData.sort((a, b) => {
+                        const dateA = parseTimestamp(a.timestamp);
+                        const dateB = parseTimestamp(b.timestamp);
+                        return dateB - dateA; // Sort descending (newest first)
+                    });
+                    renderCards(reportsData);
+                });
+            } else {
+                console.error("Sort by Date button not found.");
             }
         }
     });


### PR DESCRIPTION
This commit introduces several enhancements:

1.  **GitHub Actions Workflow (`.github/workflows/jekyll-gh-pages.yml`):**
    *   Modified the Python script to determine the last Git modification
      timestamp for each file in the `report/` directory.
    *   Timestamps are formatted as `YYYY/MM/DD HH:MM:SS`.
    *   A default timestamp (`2025/06/06 00:00:00`) is used if the actual
      timestamp cannot be retrieved.
    *   `report_list.json` is now an array of objects, each containing
      `name` (filename) and `timestamp`.

2.  **Landing Page (`index.html`):**
    *   Updated JavaScript to parse the new `report_list.json` format.
    *   Timestamps are now stored along with other report metadata.
    *   Report cards now display the last modification timestamp.
    *   Added a "Sort by Date" button to the UI.
    *   Implemented JavaScript logic to sort reports chronologically
      (newest first) based on their timestamps.
    *   Adjusted styling for the new button and timestamp display to
      ensure visual consistency.

These changes allow you to see when each report was last updated and to sort the reports accordingly on the landing page.